### PR TITLE
Fix the bundler version issues in older ruby

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,6 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - run: gem update --system
       - run: gem install bundler
       - restore_cache:
           keys:
@@ -70,8 +69,7 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - run: gem update --system
-      - run: gem install bundler
+      - run: gem install bundler -v 1.17.1
       - restore_cache:
           keys:
             - v1-gems-build_2_4-{{ .Branch }}-{{ .Revision }}
@@ -94,8 +92,7 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - run: gem update --system
-      - run: gem install bundler
+      - run: gem install bundler -v 1.17.1
       - restore_cache:
           keys:
             - v1-gems-build_2_3-{{ .Branch }}-{{ .Revision }}

--- a/onsi.gemspec
+++ b/onsi.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'addressable', '>= 2.5', '< 3.0'
   spec.add_dependency 'rails',       '>= 5.0', '< 6.0'
 
-  spec.add_development_dependency 'bundler',          '~> 2.0'
+  spec.add_development_dependency 'bundler',          '>= 1.16', '< 3.0'
   spec.add_development_dependency 'database_cleaner', '~> 1.7.0'
   spec.add_development_dependency 'pry',              '~> 0.11.3'
   spec.add_development_dependency 'rake',             '~> 10.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'simplecov'
 
 SimpleCov.start do
   add_filter 'spec/'
+  add_filter 'vendor/'
 end
 
 require_relative 'dummy/config/environment'


### PR DESCRIPTION
Thanks for opening a pull request!

Before you get started there are a few things to do.

1. Make sure the specs pass.

  `$ bundle exec rspec`

2. Make sure rubocop is happy(ish).

  `$ rubocop . --auto-correct`

3. Write a descriptive PR details :D
